### PR TITLE
GSoC-2022: VedicDateTime(Part A) - Publishing to CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^.dccache
 ^\.github$
 ^cran-comments\.md$
+^CRAN-SUBMISSION$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^Meta$
 ^.dccache
 ^\.github$
+^cran-comments\.md$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.1.0
+Date: 2022-09-09 13:31:35 UTC
+SHA: ff82424b8e1f0805581f934a993fe5cec4b27bc2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# VedicDateTime 0.1.0
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
 # VedicDateTime 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.
+* Status of submission to CRAN [`cransays`](https://r-hub.github.io/cransays/articles/dashboard.html)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,5 @@
-# R CMD CHECK results
+## R CMD check results
 
-There were no ERRORs, WARNINGs and NOTEs for local R CMD CHECK on Ubuntu.
+0 errors | 0 warnings | 1 note
 
-There was 1 NOTE from [win-builder](https://win-builder.r-project.org/):
-
-```{text}
-
-checking CRAN incoming feasibility ... NOTE
-
-```
+* This is a new release.


### PR DESCRIPTION
- Added changelog
- Added cran comments log
- `rhub::check_for_cran()` for Windows, Ubuntu, Apple Silicon (release only)
- Reduced size for rendered vignettes