### PR TITLE
GSoC-2022: VedicDateTime(Part A): Published to CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,4 +43,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          args: 'c("--compact-vignettes=gs+qpdf")'
+          build_args: 'c("--compact-vignettes=gs+qpdf")'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # VedicDateTime<a href='https://www.neerajbokde.in/viggnette/2022-09-05-VedicDateTime'><img src="vignettes/icon.png" alt="alt text" align="right" width="200"/>
 
 <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/VedicDateTime)](https://cran.r-project.org/package=VedicDateTime)
 [![codecov](https://codecov.io/gh/saradindusengupta/VedicDateTime/branch/main/graph/badge.svg?token=788ELH8KF6)](https://codecov.io/gh/saradindusengupta/VedicDateTime)
 [![R-CMD-check](https://github.com/saradindusengupta/VedicDateTime/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/saradindusengupta/VedicDateTime/actions/workflows/R-CMD-check.yaml)
 <!-- badges: start -->


### PR DESCRIPTION
Package published to [CRAN](https://cran.r-project.org/web/packages/VedicDateTime/index.html)