### PR TITLE
Remove the <h1> tag in subtitle

### DIFF
--- a/vignettes/VedicDateTime.Rmd
+++ b/vignettes/VedicDateTime.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "VedicDateTime"
-subtitle: <h1>An R package to implement Vedic calendar system<h1>
+subtitle: An R package to implement Vedic calendar system
 author: 
   - "Neeraj Dhanraj Bokde"
   - "Prajwal Kailasnath Patil"


### PR DESCRIPTION
This tag is causing a problem on CRAN with Pandoc 3.0.1: https://www.stats.ox.ac.uk/pub/bdr/M1mac/VedicDateTime.out