### PR TITLE
Fix multiple and out-of-bounds bug of nakshatras

### DIFF
--- a/R/nakshatra.R
+++ b/R/nakshatra.R
@@ -40,11 +40,14 @@ nakshatra <- function(jd,place){
   answer = c(as.integer(nak),to_dms(ends))
 
   # 4. Check for skipped nakshatra
-  nak_tmrw = ceiling(longitudes[length(longitudes)-1] * 27 / 360)
+  nak_tmrw = ceiling((longitudes[length(longitudes)] * 27) / 360)
   if(((nak_tmrw - nak) %% 27) > 1){
-    leap_nak = nak + 1
+    leap_nak = (nak + 1) %% 27
     approx_end = inverse_lagrange(offsets,longitudes,leap_nak*360/27)
     ends = (rise - jd + approx_end) * 24 + tz
+    if(leap_nak >= 28){
+      leap_nak = (leap_nak %% 28) + 1
+    }
     answer <- append(answer,c(as.integer(leap_nak),to_dms(ends)))
   }
   return (answer)


### PR DESCRIPTION
- [x] This fixes the bug where the `nakshatra` function would not return multiple _nakshatras_ and it would just return the first one. 
- [x] This PR also fixes the bug where the `nakshatra` would return out-of-bounds when there was a situation like _Revati_ and _Ashwini_  occurring on the same day.

### Before
```R
get_nakshatra_name(gregorian_to_jd(28,10,2023),c(16.99, 81.79, +5.5))
[1] "Revati till 7:31:26"
```

### Now
```R
get_nakshatra_name(gregorian_to_jd(28,10,2023),c(16.99, 81.79, +5.5))
[1] "Revati till 7:31:26 & Ashwini till 29:54:32"
```